### PR TITLE
unique, teller dependent, message IDs 

### DIFF
--- a/src/base/Roles/CrossChain/CrossChainOPTellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/CrossChain/CrossChainOPTellerWithMultiAssetSupport.sol
@@ -19,6 +19,7 @@ contract CrossChainOPTellerWithMultiAssetSupport is CrossChainTellerBase {
 
     uint32 public maxMessageGas;
     uint32 public minMessageGas;
+    uint128 public nonce;
 
     error CrossChainOPTellerWithMultiAssetSupport_OnlyMessenger();
     error CrossChainOPTellerWithMultiAssetSupport_OnlyPeerAsSender();
@@ -60,7 +61,7 @@ contract CrossChainOPTellerWithMultiAssetSupport is CrossChainTellerBase {
      * @param receiver to receive the shares
      * @param shareMintAmount amount of shares to mint
      */
-    function receiveBridgeMessage(address receiver, uint256 shareMintAmount) external {
+    function receiveBridgeMessage(address receiver, uint256 shareMintAmount, bytes32 messageId) external {
         _beforeReceive();
 
         if (msg.sender != address(messenger)) {
@@ -72,6 +73,8 @@ contract CrossChainOPTellerWithMultiAssetSupport is CrossChainTellerBase {
         }
 
         vault.enter(address(0), ERC20(address(0)), 0, receiver, shareMintAmount);
+
+        _afterReceive(shareMintAmount, receiver, messageId);
     }
 
     /**
@@ -79,13 +82,16 @@ contract CrossChainOPTellerWithMultiAssetSupport is CrossChainTellerBase {
      * @param data bridge data
      * @return messageId
      */
-    function _bridge(uint256 shareAmount, BridgeData calldata data) internal override returns (bytes32) {
+    function _bridge(uint256 shareAmount, BridgeData calldata data) internal override returns (bytes32 messageId) {
+        unchecked {
+            messageId = keccak256(abi.encodePacked(++nonce, address(this), block.chainid));
+        }
+        
         messenger.sendMessage(
             peer,
-            abi.encodeCall(this.receiveBridgeMessage, (data.destinationChainReceiver, shareAmount)),
+            abi.encodeCall(this.receiveBridgeMessage, (data.destinationChainReceiver, shareAmount, messageId)),
             uint32(data.messageGas)
         );
-        return bytes32(0);
     }
 
     /**

--- a/src/base/Roles/CrossChain/CrossChainTellerBase.sol
+++ b/src/base/Roles/CrossChain/CrossChainTellerBase.sol
@@ -91,12 +91,6 @@ abstract contract CrossChainTellerBase is TellerWithMultiAssetSupport {
     }
 
     /**
-     * @notice the before bridge hook to perform additional checks
-     * @param data bridge data
-     */
-    function _beforeBridge(BridgeData calldata data) internal virtual;
-
-    /**
      * @notice the virtual bridge function to be overridden
      * @param data bridge data
      * @return messageId
@@ -109,6 +103,12 @@ abstract contract CrossChainTellerBase is TellerWithMultiAssetSupport {
      * @param data bridge data
      */
     function _quote(uint256 shareAmount, BridgeData calldata data) internal view virtual returns (uint256);
+
+    /**
+     * @notice the before bridge hook to perform additional checks
+     * @param data bridge data
+     */
+    function _beforeBridge(BridgeData calldata data) internal virtual;
 
     /**
      * @notice after bridge code, just an emit but can be overriden
@@ -125,5 +125,15 @@ abstract contract CrossChainTellerBase is TellerWithMultiAssetSupport {
      */
     function _beforeReceive() internal virtual {
         if (isPaused) revert TellerWithMultiAssetSupport__Paused();
+    }
+
+    /**
+     * @notice a hook to execute after receiving
+     * @param shareAmount the shareAmount that was minted
+     * @param destinationChainReceiver the receiver of the shares
+     * @param messageId the message ID
+     */
+    function _afterReceive(uint256 shareAmount, address destinationChainReceiver, bytes32 messageId) internal virtual {
+        emit MessageReceived(messageId, shareAmount, destinationChainReceiver);
     }
 }

--- a/src/base/Roles/CrossChain/MultiChainLayerZeroTellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/CrossChain/MultiChainLayerZeroTellerWithMultiAssetSupport.sol
@@ -72,6 +72,8 @@ contract MultiChainLayerZeroTellerWithMultiAssetSupport is MultiChainTellerBase,
         // Decode the payload to get the message
         (uint256 shareAmount, address receiver) = abi.decode(payload, (uint256, address));
         vault.enter(address(0), ERC20(address(0)), 0, receiver, shareAmount);
+
+        _afterReceive(shareAmount, receiver, _guid);
     }
 
     /**


### PR DESCRIPTION
For OP, the messageID needs to be a parameter on chain2 as chain id can't be known for eachother without additional values/checks and nonce could differ. 

For LZ this is already provided