### PR TITLE
Jamie/fee idea

### DIFF
--- a/src/base/Roles/AccountantWithRateProviders.sol
+++ b/src/base/Roles/AccountantWithRateProviders.sol
@@ -324,19 +324,20 @@ contract AccountantWithRateProviders is Auth, IRateProvider {
 
             // Check if intermediate rate exceeds high water mark
             if (intermediateRate > state.highestExchangeRate && state.performanceFee > 0) {
-                uint256 profitDelta = uint256(intermediateRate - state.highestExchangeRate);
-                performanceFeesOwed =
+                uint256 oldHighWaterMark = state.highestExchangeRate;  // Store old HWM
+                uint256 profitDelta = uint256(intermediateRate - oldHighWaterMark);
+                performanceFeesOwed = 
                     profitDelta.mulDivDown(shareSupplyToUse, ONE_SHARE).mulDivDown(state.performanceFee, 1e4);
-
+    
                 // Update high water mark
                 state.highestExchangeRate = intermediateRate;
 
                 // Only apply performance fee weighted average if we actually take performance fees
-                // Calculate final exchange rate
-                // newRate = intermediateRate * (1 - pf) + pf * oldRate
+                // Use old high water mark for weighted average to calculate final exchange rate
+                // newRate = intermediateRate * (1 - pf) + pf * oldHighWaterMark
                 newExchangeRate = uint96(
                     intermediateRate.mulDivDown(uint256(1e4 - state.performanceFee), 1e4).add(
-                        currentExchangeRate.mulDivDown(state.performanceFee, 1e4)
+                        oldHighWaterMark.mulDivDown(state.performanceFee, 1e4)
                     )
                 );
             }

--- a/src/base/Roles/AccountantWithRateProviders.sol
+++ b/src/base/Roles/AccountantWithRateProviders.sol
@@ -320,6 +320,7 @@ contract AccountantWithRateProviders is Auth, IRateProvider {
 
             // Initialize performance fees
             uint256 performanceFeesOwed = 0;
+            newExchangeRate = uint96(intermediateRate);
 
             // Check if intermediate rate exceeds high water mark
             if (intermediateRate > state.highestExchangeRate && state.performanceFee > 0) {
@@ -329,13 +330,16 @@ contract AccountantWithRateProviders is Auth, IRateProvider {
 
                 // Update high water mark
                 state.highestExchangeRate = intermediateRate;
-            }
 
-            // Calculate final exchange rate
-            // newRate = intermediateRate * (1 - pf) + pf * oldRate
-            newExchangeRate = intermediateRate.mulDivDown(uint256(1e4 - state.performanceFee), 1e4).add(
-                currentExchangeRate.mulDivDown(state.performanceFee, 1e4)
-            );
+                // Only apply performance fee weighted average if we actually take performance fees
+                // Calculate final exchange rate
+                // newRate = intermediateRate * (1 - pf) + pf * oldRate
+                newExchangeRate = uint96(
+                    intermediateRate.mulDivDown(uint256(1e4 - state.performanceFee), 1e4).add(
+                        currentExchangeRate.mulDivDown(state.performanceFee, 1e4)
+                    )
+                );
+            }
 
             // Update total fees owed
             state.feesOwedInBase += uint128(managementFeesOwed + performanceFeesOwed);

--- a/src/base/Roles/AccountantWithRateProviders.sol
+++ b/src/base/Roles/AccountantWithRateProviders.sol
@@ -355,15 +355,15 @@ contract AccountantWithRateProviders is Auth, IRateProvider {
                 uint256 postAllFeesAUM = shareSupplyToUse.mulDivDown(newExchangeRate, ONE_SHARE);
                 performanceFeesOwed = postManagementFeeAUM - postAllFeesAUM;
             }
+            // update state and emit events
+            state.exchangeRate = newExchangeRate;
+            state.totalSharesLastUpdate = uint128(currentTotalShares);
+            state.lastUpdateTimestamp = currentTime;
+            state.feesOwedInBase += uint128(managementFeesOwed + performanceFeesOwed);
+
+            emit FeesCalculated(managementFeesOwed, performanceFeesOwed);
+            emit ExchangeRateUpdated(uint96(currentExchangeRate), newExchangeRate, currentTime);
         }
-
-        state.exchangeRate = newExchangeRate;
-        state.totalSharesLastUpdate = uint128(currentTotalShares);
-        state.lastUpdateTimestamp = currentTime;
-        state.feesOwedInBase += uint128(managementFeesOwed + performanceFeesOwed);
-
-        emit FeesCalculated(managementFeesOwed, performanceFeesOwed);
-        emit ExchangeRateUpdated(uint96(currentExchangeRate), newExchangeRate, currentTime);
     }
 
     /**

--- a/src/base/Roles/AccountantWithRateProviders.sol
+++ b/src/base/Roles/AccountantWithRateProviders.sol
@@ -324,11 +324,11 @@ contract AccountantWithRateProviders is Auth, IRateProvider {
 
             // Check if intermediate rate exceeds high water mark
             if (intermediateRate > state.highestExchangeRate && state.performanceFee > 0) {
-                uint256 oldHighWaterMark = state.highestExchangeRate;  // Store old HWM
+                uint256 oldHighWaterMark = state.highestExchangeRate; // Store old HWM
                 uint256 profitDelta = uint256(intermediateRate - oldHighWaterMark);
-                performanceFeesOwed = 
+                performanceFeesOwed =
                     profitDelta.mulDivDown(shareSupplyToUse, ONE_SHARE).mulDivDown(state.performanceFee, 1e4);
-    
+
                 // Update high water mark
                 state.highestExchangeRate = intermediateRate;
 

--- a/src/base/Roles/AccountantWithRateProviders.sol
+++ b/src/base/Roles/AccountantWithRateProviders.sol
@@ -314,7 +314,7 @@ contract AccountantWithRateProviders is Auth, IRateProvider {
                 shareSupplyToUse = state.totalSharesLastUpdate;
             }
 
-            // Calculate intermediate rate directly with management fee time impact
+            // Calculate intermediate rate directly with (time-weighted) management fee
             // intermediateRate = rawRate - rawRate * (managementFee * timeDelta)/(year * 1e4)
             uint256 intermediateRate =
                 rawExchangeRate - rawExchangeRate.mulDivDown(state.managementFee * timeDeltaSeconds, 365 days * 1e4);
@@ -333,8 +333,8 @@ contract AccountantWithRateProviders is Auth, IRateProvider {
 
             // Check if intermediate rate exceeds high water mark
             // If so, calculate performance fees and update new rate
-            // Performance fees are calculated as the difference in AUM between the post management fee AUM and the post
-            // performance fee AUM
+            // Performance fees are calculated as difference between post management fee AUM
+            // and post performance fee AUM
             // postPerformanceFeeAUM = postManagementFeeAUM - performanceFeesOwed
             if (intermediateRate > state.highestExchangeRate && state.performanceFee > 0) {
                 // cache old high water mark

--- a/src/base/Roles/AccountantWithRateProviders.sol
+++ b/src/base/Roles/AccountantWithRateProviders.sol
@@ -331,8 +331,7 @@ contract AccountantWithRateProviders is Auth, IRateProvider {
             if (intermediateRate > state.highestExchangeRate && state.performanceFee > 0) {
                 uint256 oldHighWaterMark = state.highestExchangeRate;
                 uint256 profitDelta = uint256(intermediateRate - oldHighWaterMark);
-                performanceFeesOwed =
-                    profitDelta.mulDivDown(shareSupplyToUse, ONE_SHARE).mulDivDown(state.performanceFee, 1e4);
+                performanceFeesOwed = profitDelta.mulDivDown(shareSupplyToUse * state.performanceFee, ONE_SHARE * 1e4);
 
                 // Update high water mark
                 state.highestExchangeRate = intermediateRate;


### PR DESCRIPTION
- idea to make the rates be
1) independent of supply (important across multi-chain deployments, as long as new rate, old rate, and fees are same cross chain, then new highwater mark and new rate should be the same if time deltas passed in are same)
2) use AUM management fee first (basically management fees will be taken on raw AUM first independent of performance similar to how management fees are independent of performance with a fund)
3) only take performance fees AFTER management fees are deducted

- in addition, the event will emit these fees separately for easier tracking
