### PR TITLE
Reah Configs + Script for WithdrawQueueAssetSpecificFeeModule

### DIFF
--- a/deployment-config/chains/1.json
+++ b/deployment-config/chains/1.json
@@ -13,7 +13,14 @@
       "isPegged": true,
       "rateProvider": "0x0000000000000000000000000000000000000000"
     },
-    "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0": {
+    "0xdac17f958d2ee523a2206206994597c13d831ec7": {
+      "isPegged": true,
+      "rateProvider": "0x0000000000000000000000000000000000000000"
+    },
+    "0x6c3ea9036406852006290770bedfcaba0e23a0e8": {
+      "isPegged": true,
+      "rateProvider": "0x0000000000000000000000000000000000000000"
+    },    "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0": {
       "isPegged": false,
       "denomination": "stETH/wstETH",
       "priceFeedType": 2,

--- a/deployment-config/exampleL1.json
+++ b/deployment-config/exampleL1.json
@@ -6,6 +6,7 @@
   "boringVault": {
     "boringVaultName": "Nucleus Vault",
     "boringVaultSymbol": "NV",
+    "beforeTransferHookAddress": "0x2e30D7903f69063be7B5C5B374648dc9Fc7FB7Ee",
     "address": "0x0000000000E7Ab44153eEBEF2343ba5289F65dAC"
   },
   "freezeListBeforeTransferHook": {

--- a/deployment-config/exampleL1.json
+++ b/deployment-config/exampleL1.json
@@ -70,7 +70,6 @@
   },
   "distributorCodeDepositor": {
     "deploy": true,
-    "distributorCodeDepositorSalt": "0x48b53893da2e0b0248268c00000000000000000000000000000000000000001d",
     "supplyCap": "1000000000000000000000000000",
     "registry": "0xe15a8Ca5BD8464283818088c1760d8f23B6a216E",
     "policyID": "policyOne",
@@ -80,7 +79,6 @@
     "name": "Example Withdraw Queue",
     "symbol": "EWQ",
     "feeRecipient": "0x0000000000417626Ef34D62C4DC189b021603f2F",
-    "feePercentage": "100",
     "minimumOrderSize": "1000000000000000000",
     "processorAddress": "0x00000000004F96C07B83e86600D86F0000000000"
   }

--- a/deployment-config/reahUSDGc.json
+++ b/deployment-config/reahUSDGc.json
@@ -6,6 +6,7 @@
   "boringVault": {
     "boringVaultName": "Reah USDG Core",
     "boringVaultSymbol": "reahUSDGc",
+    "beforeTransferHookAddress": "0x2e30D7903f69063be7B5C5B374648dc9Fc7FB7Ee",
     "address": "0x0000000000000000000000000000000000000000"
   },
   "freezeListBeforeTransferHook": {

--- a/deployment-config/reahUSDGc.json
+++ b/deployment-config/reahUSDGc.json
@@ -27,7 +27,7 @@
     "maxGasForPeer": 100000,
     "minGasForPeer": 0,
     "peerEid": 0,
-    "tellerContractName": "MultiChainLayerZeroTellerWithMultiAssetSupport",
+    "tellerContractName": "TellerWithMultiAssetSupport",
     "withdrawAssets": [
       "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
       "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",

--- a/deployment-config/reahUSDGc.json
+++ b/deployment-config/reahUSDGc.json
@@ -1,0 +1,72 @@
+{
+  "nameEntropy": "reahUSDGc",
+  "base": "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
+  "protocolAdmin": "0x0000000000417626Ef34D62C4DC189b021603f2F",
+  "boringVaultAndBaseDecimals": "6",
+  "boringVault": {
+    "boringVaultName": "Reah USDG Core",
+    "boringVaultSymbol": "reahUSDGc",
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "freezeListBeforeTransferHook": {
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "manager": {
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "accountant": {
+    "payoutAddress": "0x0000000000417626Ef34D62C4DC189b021603f2F",
+    "allowedExchangeRateChangeUpper": "10004",
+    "allowedExchangeRateChangeLower": "10000",
+    "minimumUpdateDelayInSeconds": "3600",
+    "managementFee": "0",
+    "performanceFee": "2000",
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "teller": {
+    "maxGasForPeer": 100000,
+    "minGasForPeer": 0,
+    "peerEid": 0,
+    "tellerContractName": "MultiChainLayerZeroTellerWithMultiAssetSupport",
+    "withdrawAssets": [
+      "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
+    ],
+    "depositAssets": [
+      "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
+    ],
+    "dvnIfNoDefault": {
+      "required": [
+      ],
+      "optional": [
+      ],
+      "blockConfirmationsRequiredIfNoDefault": 15,
+      "optionalThreshold": 1
+    },
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "rolesAuthority": {
+    "strategist": "0x63bEE0Dd9Ea59Ca410A1FA9208938F412cE10EcE",
+    "exchangeRateBot": "0x1755397BEc366a1e1160d8aE0106C60E7e344B56",
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "distributorCodeDepositor": {
+    "deploy": true,
+    "supplyCap": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+    "registry": "0xe15a8Ca5BD8464283818088c1760d8f23B6a216E",
+    "policyID": "",
+    "nativeSupported": false
+  },
+  "withdrawQueue": {
+    "name": "Reah USDG Core Withdraw Queue",
+    "symbol": "reahUSDGcQ",
+    "feeRecipient": "0x0000000000417626Ef34D62C4DC189b021603f2F",
+    "minimumOrderSize": "5000000",
+    "processorAddress": "0x0b04272A9db2f889FC5286a1Bfe9C33e5d313e51"
+  }
+}

--- a/deployment-config/reahUSDGf.json
+++ b/deployment-config/reahUSDGf.json
@@ -6,6 +6,7 @@
   "boringVault": {
     "boringVaultName": "Reah USDG Frontier",
     "boringVaultSymbol": "reahUSDGf",
+    "beforeTransferHookAddress": "0x2e30D7903f69063be7B5C5B374648dc9Fc7FB7Ee",
     "address": "0x0000000000000000000000000000000000000000"
   },
   "freezeListBeforeTransferHook": {

--- a/deployment-config/reahUSDGf.json
+++ b/deployment-config/reahUSDGf.json
@@ -27,7 +27,7 @@
     "maxGasForPeer": 100000,
     "minGasForPeer": 0,
     "peerEid": 0,
-    "tellerContractName": "MultiChainLayerZeroTellerWithMultiAssetSupport",
+    "tellerContractName": "TellerWithMultiAssetSupport",
     "withdrawAssets": [
       "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
       "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",

--- a/deployment-config/reahUSDGf.json
+++ b/deployment-config/reahUSDGf.json
@@ -1,0 +1,72 @@
+{
+  "nameEntropy": "reahUSDGf",
+  "base": "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
+  "protocolAdmin": "0x0000000000417626Ef34D62C4DC189b021603f2F",
+  "boringVaultAndBaseDecimals": "6",
+  "boringVault": {
+    "boringVaultName": "Reah USDG Frontier",
+    "boringVaultSymbol": "reahUSDGf",
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "freezeListBeforeTransferHook": {
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "manager": {
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "accountant": {
+    "payoutAddress": "0x0000000000417626Ef34D62C4DC189b021603f2F",
+    "allowedExchangeRateChangeUpper": "10004",
+    "allowedExchangeRateChangeLower": "10000",
+    "minimumUpdateDelayInSeconds": "3600",
+    "managementFee": "0",
+    "performanceFee": "2000",
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "teller": {
+    "maxGasForPeer": 100000,
+    "minGasForPeer": 0,
+    "peerEid": 0,
+    "tellerContractName": "MultiChainLayerZeroTellerWithMultiAssetSupport",
+    "withdrawAssets": [
+      "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
+    ],
+    "depositAssets": [
+      "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
+    ],
+    "dvnIfNoDefault": {
+      "required": [
+      ],
+      "optional": [
+      ],
+      "blockConfirmationsRequiredIfNoDefault": 15,
+      "optionalThreshold": 1
+    },
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "rolesAuthority": {
+    "strategist": "0xA82dd0142F6d454a501BAd90449Fb3C79b67907B",
+    "exchangeRateBot": "0x1755397BEc366a1e1160d8aE0106C60E7e344B56",
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "distributorCodeDepositor": {
+    "deploy": true,
+    "supplyCap": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+    "registry": "0xe15a8Ca5BD8464283818088c1760d8f23B6a216E",
+    "policyID": "",
+    "nativeSupported": false
+  },
+  "withdrawQueue": {
+    "name": "Reah USDG Frontier Withdraw Queue",
+    "symbol": "reahUSDGfQ",
+    "feeRecipient": "0x0000000000417626Ef34D62C4DC189b021603f2F",
+    "minimumOrderSize": "5000000",
+    "processorAddress": "0x485896a673677548f63A8Aa16191c5F52550C960"
+  }
+}

--- a/deployment-config/reahUSDGt.json
+++ b/deployment-config/reahUSDGt.json
@@ -6,6 +6,7 @@
   "boringVault": {
     "boringVaultName": "Reah USDG Treasury",
     "boringVaultSymbol": "reahUSDGt",
+    "beforeTransferHookAddress": "0x2e30D7903f69063be7B5C5B374648dc9Fc7FB7Ee",
     "address": "0x0000000000000000000000000000000000000000"
   },
   "freezeListBeforeTransferHook": {

--- a/deployment-config/reahUSDGt.json
+++ b/deployment-config/reahUSDGt.json
@@ -1,0 +1,72 @@
+{
+  "nameEntropy": "reahUSDGt",
+  "base": "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
+  "protocolAdmin": "0x0000000000417626Ef34D62C4DC189b021603f2F",
+  "boringVaultAndBaseDecimals": "6",
+  "boringVault": {
+    "boringVaultName": "Reah USDG Treasury",
+    "boringVaultSymbol": "reahUSDGt",
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "freezeListBeforeTransferHook": {
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "manager": {
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "accountant": {
+    "payoutAddress": "0x0000000000417626Ef34D62C4DC189b021603f2F",
+    "allowedExchangeRateChangeUpper": "10004",
+    "allowedExchangeRateChangeLower": "10000",
+    "minimumUpdateDelayInSeconds": "3600",
+    "managementFee": "50",
+    "performanceFee": "0",
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "teller": {
+    "maxGasForPeer": 100000,
+    "minGasForPeer": 0,
+    "peerEid": 0,
+    "tellerContractName": "MultiChainLayerZeroTellerWithMultiAssetSupport",
+    "withdrawAssets": [
+      "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
+    ],
+    "depositAssets": [
+      "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
+    ],
+    "dvnIfNoDefault": {
+      "required": [
+      ],
+      "optional": [
+      ],
+      "blockConfirmationsRequiredIfNoDefault": 15,
+      "optionalThreshold": 1
+    },
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "rolesAuthority": {
+    "strategist": "0x54750504b83187a684a8Bdb5555574aE5F291f7C",
+    "exchangeRateBot": "0x1755397BEc366a1e1160d8aE0106C60E7e344B56",
+    "address": "0x0000000000000000000000000000000000000000"
+  },
+  "distributorCodeDepositor": {
+    "deploy": true,
+    "supplyCap": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+    "registry": "0xe15a8Ca5BD8464283818088c1760d8f23B6a216E",
+    "policyID": "",
+    "nativeSupported": false
+  },
+  "withdrawQueue": {
+    "name": "Reah USDG Treasury Withdraw Queue",
+    "symbol": "reahUSDGtQ",
+    "feeRecipient": "0x0000000000417626Ef34D62C4DC189b021603f2F",
+    "minimumOrderSize": "5000000",
+    "processorAddress": "0x5b5590b1978c377Dc0cb60F1bBee91F712f9b9B7"
+  }
+}

--- a/deployment-config/reahUSDGt.json
+++ b/deployment-config/reahUSDGt.json
@@ -27,7 +27,7 @@
     "maxGasForPeer": 100000,
     "minGasForPeer": 0,
     "peerEid": 0,
-    "tellerContractName": "MultiChainLayerZeroTellerWithMultiAssetSupport",
+    "tellerContractName": "TellerWithMultiAssetSupport",
     "withdrawAssets": [
       "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
       "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",

--- a/script/ConfigReader.s.sol
+++ b/script/ConfigReader.s.sol
@@ -29,6 +29,7 @@ library ConfigReader {
         uint16 performanceFee;
         string boringVaultName;
         string boringVaultSymbol;
+        address beforeTransferHookAddress;
         address balancerVault;
         uint32 peerEid;
         address[] requiredDvns;
@@ -91,6 +92,7 @@ library ConfigReader {
         config.boringVault = _config.readAddress(".boringVault.address");
         config.boringVaultName = _config.readString(".boringVault.boringVaultName");
         config.boringVaultSymbol = _config.readString(".boringVault.boringVaultSymbol");
+        config.beforeTransferHookAddress = _config.readAddress(".boringVault.beforeTransferHookAddress");
 
         // Reading from the 'manager' section
         config.manager = _config.readAddress(".manager.address");

--- a/script/ConfigReader.s.sol
+++ b/script/ConfigReader.s.sol
@@ -60,7 +60,6 @@ library ConfigReader {
         uint256 distributorCodeDepositorSupplyCap;
         address registry;
         string policyID;
-        uint256 withdrawQueueFeePercentage;
         string withdrawQueueName;
         string withdrawQueueSymbol;
         address withdrawQueueFeeRecipient;
@@ -133,7 +132,6 @@ library ConfigReader {
         config.policyID = _config.readString(".distributorCodeDepositor.policyID");
 
         // Reading from the 'withdrawQueue' section
-        config.withdrawQueueFeePercentage = uint256(_config.readUint(".withdrawQueue.feePercentage"));
         config.withdrawQueueName = _config.readString(".withdrawQueue.name");
         config.withdrawQueueSymbol = _config.readString(".withdrawQueue.symbol");
         config.withdrawQueueFeeRecipient = _config.readAddress(".withdrawQueue.feeRecipient");

--- a/script/deploy/single/03_DeployFreezeListBeforeTransferHook.s.sol
+++ b/script/deploy/single/03_DeployFreezeListBeforeTransferHook.s.sol
@@ -6,6 +6,7 @@ import { BaseScript } from "script/Base.s.sol";
 import { ConfigReader } from "script/ConfigReader.s.sol";
 import { stdJson as StdJson } from "@forge-std/StdJson.sol";
 import { FreezeListBeforeTransferHook } from "src/helper/FreezeListBeforeTransferHook.sol";
+import { console } from "@forge-std/console.sol";
 
 contract DeployFreezeListBeforeTransferHookScript is BaseScript {
 
@@ -20,29 +21,44 @@ contract DeployFreezeListBeforeTransferHookScript is BaseScript {
         require(config.boringVault != address(0), "boringVault must not be zero address");
         require(config.boringVault.code.length != 0, "boringVault must have code");
 
-        bytes32 freezeListBeforeTransferHookSalt =
-            makeSalt(broadcaster, false, string(abi.encodePacked(config.nameEntropy, ":FreezeListBeforeTransferHook")));
+        // only deploy a freeze list hook IF one is not already provided. This will probably only happen if deploying on
+        // a new chain.
+        if (config.beforeTransferHookAddress == address(0)) {
+            console.log("03_DeployFreezeListBeforeTransferHook: NO HOOK PROVIDED: Deploying new hook...");
+            bytes32 freezeListBeforeTransferHookSalt = makeSalt(
+                broadcaster, false, string(abi.encodePacked(config.nameEntropy, ":FreezeListBeforeTransferHook"))
+            );
 
-        // Create Contract
-        bytes memory creationCode = type(FreezeListBeforeTransferHook).creationCode;
-        address freezeListBeforeTransferHook = CREATEX.deployCreate3(
-            freezeListBeforeTransferHookSalt, abi.encodePacked(creationCode, abi.encode(broadcaster))
-        );
+            // Create Contract
+            bytes memory creationCode = type(FreezeListBeforeTransferHook).creationCode;
+            address freezeListBeforeTransferHook = CREATEX.deployCreate3(
+                freezeListBeforeTransferHookSalt, abi.encodePacked(creationCode, abi.encode(broadcaster))
+            );
 
-        // Set the hook on the BoringVault
-        BoringVault(payable(config.boringVault)).setBeforeTransferHook(freezeListBeforeTransferHook);
+            // Set the hook on the BoringVault
+            BoringVault(payable(config.boringVault)).setBeforeTransferHook(freezeListBeforeTransferHook);
+            console.log("New Before Transfer Hook Address: ", freezeListBeforeTransferHook);
+
+            config.beforeTransferHookAddress = freezeListBeforeTransferHook;
+            require(
+                FreezeListBeforeTransferHook(config.beforeTransferHookAddress).owner() == broadcaster,
+                "Freeze List should have admin set to deployer at deployment"
+            );
+        } else {
+            require(
+                FreezeListBeforeTransferHook(config.beforeTransferHookAddress).owner() == config.protocolAdmin,
+                "The provided freezeListBeforeTransferHook's owner does not match the provided protocolAdmin"
+            );
+            // if one is provided configure it
+            BoringVault(payable(config.boringVault)).setBeforeTransferHook(config.beforeTransferHookAddress);
+        }
 
         // Post Deploy Checks
         require(
-            address(BoringVault(payable(config.boringVault)).hook()) == freezeListBeforeTransferHook,
+            address(BoringVault(payable(config.boringVault)).hook()) == config.beforeTransferHookAddress,
             "BoringVault must have freeze hook"
         );
-        require(
-            FreezeListBeforeTransferHook(freezeListBeforeTransferHook).owner() == broadcaster,
-            "Freeze List should have admin set to deployer at deployment"
-        );
-
-        return freezeListBeforeTransferHook;
+        return config.beforeTransferHookAddress;
     }
 
 }

--- a/script/deploy/single/06b_DeployMultiChainLayerZeroTellerWithMultiAssetSupport.s.sol
+++ b/script/deploy/single/06b_DeployMultiChainLayerZeroTellerWithMultiAssetSupport.s.sol
@@ -166,6 +166,11 @@ contract DeployMultiChainLayerZeroTellerWithMultiAssetSupport is BaseScript {
             config.requiredDvns.length + config.optionalDvnThreshold > 2, "DEPLOY_06b_setConfig() DVN Count Must Be > 2"
         );
 
+        require(
+            config.optionalDvnThreshold <= config.optionalDvns.length,
+            "Optional DVN threshold is larger than the number of optional DVNs provided"
+        );
+
         bytes memory ulnConfigBytes = abi.encode(
             UlnConfig(
                 config.dvnBlockConfirmationsRequired,

--- a/script/deploy/single/06b_DeployMultiChainLayerZeroTellerWithMultiAssetSupport.s.sol
+++ b/script/deploy/single/06b_DeployMultiChainLayerZeroTellerWithMultiAssetSupport.s.sol
@@ -68,8 +68,10 @@ contract DeployMultiChainLayerZeroTellerWithMultiAssetSupport is BaseScript {
             "Address not left padded correctly"
         );
 
-        teller.setPeer(config.peerEid, leftPaddedBytes32Peer);
-        teller.addChain(config.peerEid, true, true, address(teller), config.maxGasForPeer, config.minGasForPeer);
+        if (config.peerEid != 0) {
+            teller.setPeer(config.peerEid, leftPaddedBytes32Peer);
+            teller.addChain(config.peerEid, true, true, address(teller), config.maxGasForPeer, config.minGasForPeer);
+        }
         ILayerZeroEndpointV2 endpoint = ILayerZeroEndpointV2(config.lzEndpoint);
 
         // Post Deploy Checks
@@ -159,6 +161,8 @@ contract DeployMultiChainLayerZeroTellerWithMultiAssetSupport is BaseScript {
         // sort the dvns
         config.requiredDvns = sortAddresses(config.requiredDvns);
         config.optionalDvns = sortAddresses(config.optionalDvns);
+
+        require(requiredDvns.length + config.optionalDvnThreshold > 2, "DEPLOY_06b_setConfig() DVN Count Must Be > 2");
 
         bytes memory ulnConfigBytes = abi.encode(
             UlnConfig(

--- a/script/deploy/single/06b_DeployMultiChainLayerZeroTellerWithMultiAssetSupport.s.sol
+++ b/script/deploy/single/06b_DeployMultiChainLayerZeroTellerWithMultiAssetSupport.s.sol
@@ -162,7 +162,9 @@ contract DeployMultiChainLayerZeroTellerWithMultiAssetSupport is BaseScript {
         config.requiredDvns = sortAddresses(config.requiredDvns);
         config.optionalDvns = sortAddresses(config.optionalDvns);
 
-        require(requiredDvns.length + config.optionalDvnThreshold > 2, "DEPLOY_06b_setConfig() DVN Count Must Be > 2");
+        require(
+            config.requiredDvns.length + config.optionalDvnThreshold > 2, "DEPLOY_06b_setConfig() DVN Count Must Be > 2"
+        );
 
         bytes memory ulnConfigBytes = abi.encode(
             UlnConfig(

--- a/script/deploy/single/10_DeployWithdrawQueueAndFeeModule.s.sol
+++ b/script/deploy/single/10_DeployWithdrawQueueAndFeeModule.s.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.21;
 import { BaseScript } from "./../../Base.s.sol";
 import { stdJson as StdJson } from "@forge-std/StdJson.sol";
 import { ConfigReader, IAuthority } from "../../ConfigReader.s.sol";
-import { SimpleFeeModule, IFeeModule } from "src/helper/SimpleFeeModule.sol";
+import { WithdrawQueueAssetSpecificFeeModule } from "src/helper/WithdrawQueueAssetSpecificFeeModule.sol";
 import { WithdrawQueue } from "src/base/Roles/WithdrawQueue.sol";
 import { RolesAuthority } from "@solmate/auth/authorities/RolesAuthority.sol";
 import "src/helper/Constants.sol";
@@ -39,13 +39,21 @@ contract DeployWithdrawQueueAndFeeModule is BaseScript {
         address feeModule;
         {
             // Deploy the Fee Module
-            bytes32 feeModuleSalt =
-                makeSalt(broadcaster, false, string(abi.encodePacked(config.nameEntropy, ":SimpleFeeModule")));
-            bytes memory feeModuleCreationCode = type(SimpleFeeModule).creationCode;
+            bytes32 feeModuleSalt = makeSalt(
+                broadcaster, false, string(abi.encodePacked(config.nameEntropy, ":WithdrawQueueAssetSpecificFeeModule"))
+            );
+            bytes memory feeModuleCreationCode = type(WithdrawQueueAssetSpecificFeeModule).creationCode;
             feeModule = CREATEX.deployCreate3(
-                feeModuleSalt, abi.encodePacked(feeModuleCreationCode, abi.encode(config.withdrawQueueFeePercentage))
+                feeModuleSalt,
+                abi.encodePacked(feeModuleCreationCode, abi.encode(config.protocolAdmin, config.accountant))
             );
         }
+
+        require(
+            address(WithdrawQueueAssetSpecificFeeModule(feeModule).accountant()) == config.accountant,
+            "accountant mismatch"
+        );
+
         // Deploy the Withdraw Queue
         bytes32 withdrawQueueSalt =
             makeSalt(broadcaster, false, string(abi.encodePacked(config.nameEntropy, ":WithdrawQueue")));

--- a/script/deploy/single/10_DeployWithdrawQueueAndFeeModule.s.sol
+++ b/script/deploy/single/10_DeployWithdrawQueueAndFeeModule.s.sol
@@ -54,6 +54,8 @@ contract DeployWithdrawQueueAndFeeModule is BaseScript {
             "accountant mismatch"
         );
 
+        require(WithdrawQueueAssetSpecificFeeModule(feeModule).owner() == config.protocolAdmin, "owner mismatch");
+
         // Deploy the Withdraw Queue
         bytes32 withdrawQueueSalt =
             makeSalt(broadcaster, false, string(abi.encodePacked(config.nameEntropy, ":WithdrawQueue")));

--- a/script/deploy/single/11_SetAuthorityAndTransferOwnerships.s.sol
+++ b/script/deploy/single/11_SetAuthorityAndTransferOwnerships.s.sol
@@ -57,7 +57,6 @@ contract SetAuthorityAndTransferOwnerships is BaseScript {
         IAuthority(config.manager).setAuthority(config.rolesAuthority);
         IAuthority(config.teller).setAuthority(config.rolesAuthority);
         IAuthority(config.withdrawQueue).setAuthority(config.rolesAuthority);
-        IAuthority(config.freezeListBeforeTransferHook).setAuthority(config.rolesAuthority);
 
         IAuthority(config.boringVault).transferOwnership(config.protocolAdmin);
         IAuthority(config.manager).transferOwnership(config.protocolAdmin);
@@ -65,7 +64,13 @@ contract SetAuthorityAndTransferOwnerships is BaseScript {
         IAuthority(config.teller).transferOwnership(config.protocolAdmin);
         IAuthority(config.withdrawQueue).transferOwnership(config.protocolAdmin);
         IAuthority(config.rolesAuthority).transferOwnership(config.protocolAdmin);
-        IAuthority(config.freezeListBeforeTransferHook).transferOwnership(config.protocolAdmin);
+
+        // If the hook was recently deployed as a part of this script, it's owner will be the broadcaster and not the
+        // multisig yet. If this is the case set it's authority and owner to finish setup
+        if (IAuthority(config.freezeListBeforeTransferHook).owner() == broadcaster) {
+            IAuthority(config.freezeListBeforeTransferHook).setAuthority(config.rolesAuthority);
+            IAuthority(config.freezeListBeforeTransferHook).transferOwnership(config.protocolAdmin);
+        }
 
         // No need to transfer ownership to distributor code depositor as it is set to protocolAdmin in deployment.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Withdraw-queue fee handling switched to an asset-specific fee module; deployments now require and validate protocol admin and accountant addresses. Static withdraw-queue fee percentage removed from configs; distributor depositor salt removed.
  * Added vault pre-transfer hook support and conditional hook deployment/validation; authority transfers for the hook are now conditional.
  * Teller peer setup runs only when a peer ID is provided; added DVN count/threshold validations.

* **New**
  * Added three deployment configuration presets for reahUSDGc, reahUSDGf, and reahUSDGt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->