### PR TITLE
Fix case-sensitive imports

### DIFF
--- a/script/upgrade/RedEnvelope/GenerateRedEnvelopeCalldata_Sepolia.s.sol
+++ b/script/upgrade/RedEnvelope/GenerateRedEnvelopeCalldata_Sepolia.s.sol
@@ -7,7 +7,7 @@ import { IAccountantWithRateProviders } from "src/interfaces/Roles/IAccountantWi
 import { ITellerWithMultiAssetSupport } from "src/interfaces/Roles/ITellerWithMultiAssetSupport.sol";
 import { RolesAuthority } from "@solmate/auth/authorities/RolesAuthority.sol";
 import { TELLER_ROLE } from "src/helper/Constants.sol";
-import { console } from "@forge-std/Console.sol";
+import { console } from "@forge-std/console.sol";
 
 /**
  * Generates calldata for the multisig to call RedEnvelope.flashUpgrade(...) and simulates the call as multisig.

--- a/script/upgrade/RedEnvelope/GenerateRedEnvelopeCalldata_pxlPYUSDc.s.sol
+++ b/script/upgrade/RedEnvelope/GenerateRedEnvelopeCalldata_pxlPYUSDc.s.sol
@@ -7,7 +7,7 @@ import { IAccountantWithRateProviders } from "src/interfaces/Roles/IAccountantWi
 import { ITellerWithMultiAssetSupport } from "src/interfaces/Roles/ITellerWithMultiAssetSupport.sol";
 import { RolesAuthority } from "@solmate/auth/authorities/RolesAuthority.sol";
 import { TELLER_ROLE } from "src/helper/Constants.sol";
-import { console } from "@forge-std/Console.sol";
+import { console } from "@forge-std/console.sol";
 
 /**
  * Generates calldata for the multisig to call RedEnvelope.flashUpgrade(...) and simulates the call as multisig.

--- a/script/upgrade/RedEnvelope/GenerateRedEnvelopeCalldata_pxlUSDCc.s.sol
+++ b/script/upgrade/RedEnvelope/GenerateRedEnvelopeCalldata_pxlUSDCc.s.sol
@@ -7,7 +7,7 @@ import { IAccountantWithRateProviders } from "src/interfaces/Roles/IAccountantWi
 import { ITellerWithMultiAssetSupport } from "src/interfaces/Roles/ITellerWithMultiAssetSupport.sol";
 import { RolesAuthority } from "@solmate/auth/authorities/RolesAuthority.sol";
 import { TELLER_ROLE } from "src/helper/Constants.sol";
-import { console } from "@forge-std/Console.sol";
+import { console } from "@forge-std/console.sol";
 
 /**
  * Generates calldata for the multisig to call RedEnvelope.flashUpgrade(...) and simulates the call as multisig.

--- a/script/upgrade/RedEnvelope/GenerateRedEnvelopeCalldata_pxlUSDGc.s.sol
+++ b/script/upgrade/RedEnvelope/GenerateRedEnvelopeCalldata_pxlUSDGc.s.sol
@@ -7,7 +7,7 @@ import { IAccountantWithRateProviders } from "src/interfaces/Roles/IAccountantWi
 import { ITellerWithMultiAssetSupport } from "src/interfaces/Roles/ITellerWithMultiAssetSupport.sol";
 import { RolesAuthority } from "@solmate/auth/authorities/RolesAuthority.sol";
 import { TELLER_ROLE } from "src/helper/Constants.sol";
-import { console } from "@forge-std/Console.sol";
+import { console } from "@forge-std/console.sol";
 
 /**
  * Generates calldata for the multisig to call RedEnvelope.flashUpgrade(...) and simulates the call as multisig.

--- a/script/upgrade/RedEnvelope/GenerateRedEnvelopeCalldata_pxlUSDTc.s.sol
+++ b/script/upgrade/RedEnvelope/GenerateRedEnvelopeCalldata_pxlUSDTc.s.sol
@@ -7,7 +7,7 @@ import { IAccountantWithRateProviders } from "src/interfaces/Roles/IAccountantWi
 import { ITellerWithMultiAssetSupport } from "src/interfaces/Roles/ITellerWithMultiAssetSupport.sol";
 import { RolesAuthority } from "@solmate/auth/authorities/RolesAuthority.sol";
 import { TELLER_ROLE } from "src/helper/Constants.sol";
-import { console } from "@forge-std/Console.sol";
+import { console } from "@forge-std/console.sol";
 
 /**
  * Generates calldata for the multisig to call RedEnvelope.flashUpgrade(...) and simulates the call as multisig.


### PR DESCRIPTION
Compilation fails on Linux without this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development script imports to use standardized naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paxoslabs/nucleus-boring-vault/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->