### PR TITLE
feat: add submitOrder decoder for WithdrawQueue

### DIFF
--- a/src/base/DecodersAndSanitizers/Protocols/NucleusDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/NucleusDecoderAndSanitizer.sol
@@ -174,9 +174,15 @@ abstract contract NucleusDecoderAndSanitizer is BaseDecoderAndSanitizer {
     function submitOrder(IWithdrawQueue.SubmitOrderParams calldata params)
         external
         pure
-        returns (bytes memory addressesFound)
+        returns (bytes memory argumentsFound)
     {
-        addressesFound = abi.encodePacked(params.wantAsset, params.receiver, params.refundReceiver);
+        argumentsFound = abi.encodePacked(
+            params.wantAsset,
+            params.receiver,
+            params.refundReceiver,
+            params.signatureParams.approvalMethod,
+            params.signatureParams.submitWithSignature
+        );
     }
 
 }

--- a/src/base/DecodersAndSanitizers/Protocols/NucleusDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/NucleusDecoderAndSanitizer.sol
@@ -171,6 +171,8 @@ abstract contract NucleusDecoderAndSanitizer is BaseDecoderAndSanitizer {
     // @tag wantAsset:address:ERC20 asset being requested
     // @tag receiver:address:receiver of the NFT receipt
     // @tag refundReceiver:address:receiver of refunds
+    // @tag approvalMethod:uint8:token approval mechanism
+    // @tag submitWithSignature:bool:whether order includes depositor signature
     function submitOrder(IWithdrawQueue.SubmitOrderParams calldata params)
         external
         pure

--- a/src/base/DecodersAndSanitizers/Protocols/NucleusDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/NucleusDecoderAndSanitizer.sol
@@ -5,6 +5,7 @@ import { BaseDecoderAndSanitizer } from "src/base/DecodersAndSanitizers/BaseDeco
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { BridgeData } from "src/base/Roles/CrossChain/CrossChainTellerBase.sol";
 import { DecoderCustomTypes } from "src/interfaces/DecoderCustomTypes.sol";
+import { IWithdrawQueue } from "src/interfaces/Roles/IWithdrawQueue.sol";
 
 abstract contract NucleusDecoderAndSanitizer is BaseDecoderAndSanitizer {
 
@@ -164,6 +165,20 @@ abstract contract NucleusDecoderAndSanitizer is BaseDecoderAndSanitizer {
     // @desc process orders using the one to one queue
     function processOrders(uint256 ordersToProcess) external pure returns (bytes memory addressesFound) {
         // Nothing to decode
+    }
+
+    // @desc submit an order to the withdraw queue
+    // @tag wantAsset:address:ERC20 asset being requested
+    // @tag intendedDepositor:address:depositor address
+    // @tag receiver:address:receiver of the NFT receipt
+    // @tag refundReceiver:address:receiver of refunds
+    function submitOrder(IWithdrawQueue.SubmitOrderParams calldata params)
+        external
+        pure
+        returns (bytes memory addressesFound)
+    {
+        addressesFound =
+            abi.encodePacked(params.wantAsset, params.intendedDepositor, params.receiver, params.refundReceiver);
     }
 
 }

--- a/src/base/DecodersAndSanitizers/Protocols/NucleusDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/NucleusDecoderAndSanitizer.sol
@@ -169,7 +169,6 @@ abstract contract NucleusDecoderAndSanitizer is BaseDecoderAndSanitizer {
 
     // @desc submit an order to the withdraw queue
     // @tag wantAsset:address:ERC20 asset being requested
-    // @tag intendedDepositor:address:depositor address
     // @tag receiver:address:receiver of the NFT receipt
     // @tag refundReceiver:address:receiver of refunds
     function submitOrder(IWithdrawQueue.SubmitOrderParams calldata params)
@@ -177,8 +176,7 @@ abstract contract NucleusDecoderAndSanitizer is BaseDecoderAndSanitizer {
         pure
         returns (bytes memory addressesFound)
     {
-        addressesFound =
-            abi.encodePacked(params.wantAsset, params.intendedDepositor, params.receiver, params.refundReceiver);
+        addressesFound = abi.encodePacked(params.wantAsset, params.receiver, params.refundReceiver);
     }
 
 }


### PR DESCRIPTION
Depends on #302 because I can't compile otherwise.

Need to verify whether `intendedDepositor` needs to be gated before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for order submission flows, including handling of order parameters and signature-based submission.

* **Chores**
  * Updated internal development script library references and imports for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->