### PR TITLE
equivalent exchange: micro manager to assert token balances on manage calls

### DIFF
--- a/src/helper/equivalent-exchange/CLAUDE.md
+++ b/src/helper/equivalent-exchange/CLAUDE.md
@@ -1,0 +1,146 @@
+# EquivalentExchange
+
+## Purpose
+
+`EquivalentExchange` (EE) is a stateless helper that sanitizes **1:1 swaps**: a caller hands it
+a set of tokens and an arbitrary list of calls (a swap route), EE performs the calls, returns its
+**entire** balance of those tokens to the caller, and reverts unless the total value returned is
+**greater than or equal to** the total value pulled in — where every token is treated as worth one
+unit of every other token (1:1), normalized for decimals.
+
+It exists so that swap routes executed by a `BoringVault` can be gated to *guarantee no net loss of
+principal*, regardless of what the underlying swap calls do.
+
+## Where it sits
+
+```
+strategist
+  └─ ManagerWithMerkleVerification.manageVaultWithMerkleVerification(...)   (merkle-gated)
+       └─ BoringVault.manage(EquivalentExchange, execute(...), 0)
+            └─ EquivalentExchange.execute(tokens, amountsIn, targets, targetData)
+                 ├─ pulls `amountsIn` from the vault (msg.sender) via transferFrom
+                 ├─ runs the arbitrary (targets, targetData) calls  (the actual swap)
+                 ├─ sweeps its ENTIRE balance of every listed token back to the vault
+                 └─ requires totalOut >= totalIn  (else revert)
+```
+
+`EquivalentExchange` is a **target**, not a manager. The `BoringVault` calls it through a normal
+`manage` call. Because the `ManagerWithMerkleVerification` leaf commits to the target plus the
+address arguments extracted by a decoder/sanitizer, the merkle tree controls **which tokens and
+which call-targets** a strategist may route through EE. The `out >= in` invariant then bounds the
+economic outcome of whatever those calls do.
+
+### Typical manage sequence
+
+A strategist rebalancing the vault via EE issues these merkle-gated `manage` calls in one batch:
+
+1. `USDC.approve(EquivalentExchange, amountIn)` — vault approves EE for **exactly** what EE will pull.
+2. (optional) `USDT.transfer(EquivalentExchange, subsidy)` — vault pre-funds a subsidy directly to EE.
+3. `EquivalentExchange.execute([USDC, USDT], [amountIn, 0], targets, targetData)` — EE pulls USDC, runs the
+   swap calls, sweeps all USDC+USDT back, and asserts the vault received `>=` what it put in.
+
+## The invariant
+
+Let `tokens` be the listed tokens and `amountsIn` the amount of each pulled from the caller.
+
+- `totalIn  = Σ normalize(amountsIn[i], decimals[i])`
+- `totalOut = Σ normalize(balanceOf(EE)[i], decimals[i])`  (measured after the calls, then swept out)
+- Reverts unless `totalOut >= totalIn`.
+
+`normalize(amount, decimals)` rescales `amount` to 18 decimals so that one whole unit of any token
+counts the same as one whole unit of any other. Tokens with `<= 18` decimals are scaled up
+(lossless); tokens with `> 18` decimals are scaled down. This matches the decimal-normalization
+approach used by the `one-to-one-queue` helper.
+
+### What is and isn't protected
+
+- **Principal is protected.** `totalIn` counts only what EE pulls via `transferFrom`. The caller is
+  guaranteed to receive at least that much value back (1:1, normalized).
+- **The subsidy is deliberately *not* protected.** A subsidy is value sent to EE *outside* of
+  `amountsIn` (a direct transfer before the call, or any pre-existing EE balance). It is included in
+  `totalOut` but not `totalIn`, so it can be fully consumed to cover swap losses — that is its entire
+  purpose. The amount of subsidy is therefore the maximum loss a single `execute` can incur, and is
+  bounded by the strategist per call. Targets routed through EE must be trusted (merkle-gated)
+  because, within the subsidy budget, the calls have latitude over EE's transient balance.
+
+## No dangling approvals (caller → EE)
+
+After pulling, EE requires `allowance(msg.sender, EquivalentExchange) == 0` for **every** listed
+token, and does this **before** running the arbitrary calls.
+
+This is a security control, not just hygiene. While EE runs the `(targets, targetData)` calls, *EE is the
+`msg.sender`* of those calls. If the caller had left a non-zero allowance to EE, a call could direct
+EE to `transferFrom` additional tokens out of the caller, beyond `amountsIn`. Forcing the allowance
+to zero first means EE holds no power to pull more from the caller during the call phase. It also
+enforces that the caller approves *exactly* what is pulled — no lingering allowance survives the call.
+
+Approvals that EE grants outward to swap venues (inside `targetData`) are intentionally **not** reset.
+They cannot cause loss: EE holds no tokens between calls (it sweeps everything every time), the
+reentrancy guard blocks re-entry mid-call, and the `out >= in` invariant bounds every outcome. So a
+leftover EE→venue allowance is inert.
+
+## Reentrancy guard (required)
+
+`execute` is `nonReentrant`. This is one of the cases where a lock is genuinely necessary rather than
+replaceable by checks-effects-interactions ordering: EE sweeps its **entire** balance to the caller,
+not a per-call delta, and the swap calls are inherently mid-flow.
+
+Without the guard, a malicious or compromised swap target could re-enter `execute` while an outer
+call is in progress and sweep the outer call's transient balance — including a pre-funded subsidy —
+to itself. The outer invariant would not catch this, because the subsidy is not part of `totalIn`.
+Concretely: vault pulls 100 USDC (`totalIn = 100`) and pre-funds 100 USDT of subsidy; a re-entrant
+call sweeps the 100 USDT to an attacker; the outer call still returns the 100 USDC, so
+`totalOut (100) >= totalIn (100)` passes while the subsidy is stolen. The lock prevents the
+re-entry, so each `execute` observes only its own funds.
+
+## Access control
+
+`execute` is **permissionless** by design. Safety comes from the invariant, not from an allowlist:
+
+- EE pulls via `transferFrom(msg.sender, ...)`, so a third party can never spend the vault's approval
+  — it only ever pulls from whoever is calling.
+- Any caller is guaranteed `out >= in` for itself.
+- Use by the vault is separately gated upstream by `ManagerWithMerkleVerification`.
+
+EE holds no funds at rest and has no owner, admin functions, or upgradability.
+
+## Merkle integration (companion decoder required)
+
+To route the vault through EE, the `ManagerWithMerkleVerification` tree needs a decoder/sanitizer
+whose `execute(...)` selector matches EE's and which returns the packed address arguments the leaf
+commits to: every entry of `tokens` followed by every entry of `targets`. (See
+`src/base/DecodersAndSanitizers` for the canonical pattern — array arguments are packed by appending
+each element.) This decoder is a separate contract from EE and is **not** included here yet.
+
+Note the trust boundary this creates: the merkle leaf pins the token set and the call-targets, but
+the per-target calldata (`targetData`) is free. Security of the vault's principal does not rest on
+restricting that calldata — it rests on the `out >= in` invariant. The merkle gating bounds *which*
+venues and tokens are reachable and (with the subsidy budget) thereby bounds discretionary loss.
+
+## Token assumptions
+
+- Standard ERC20 behavior. Each token must implement `decimals()`, `balanceOf`, `transfer`,
+  `transferFrom`, and `allowance`.
+- Fee-on-transfer / rebasing tokens are **not** supported: EE accounts using observed balances and a
+  1:1 value model, so transfer fees or rebases would misstate `totalIn`/`totalOut`. Do not list them.
+- Tokens treated 1:1 should be genuinely interchangeable in value (e.g. a basket of stablecoins).
+  Listing tokens whose real values diverge would let the invariant pass while extracting value, up to
+  the divergence; the merkle tree is responsible for only pairing equivalent assets.
+
+## Function reference
+
+`execute(ERC20[] tokens, uint256[] amountsIn, address[] targets, bytes[] targetData)`
+- `tokens` / `amountsIn` — parallel arrays. `amountsIn[i]` is pulled from the caller for `tokens[i]`
+  (use `0` for an output-only token that EE should still sweep back and count toward `totalOut`).
+- `targets` / `targetData` — parallel arrays of arbitrary calls EE makes in order (the swap route,
+  including any approvals the venues need).
+- Reverts: `LengthMismatch`, `DanglingApproval(token)`, `InsufficientReturn(totalIn, totalOut)`, or
+  bubbles a failing call's revert.
+- Emits `Executed(caller, totalIn, totalOut)` (amounts normalized to 18 dp).
+
+## Status / TODO
+
+- [ ] Comments / NatSpec (intentionally omitted for now).
+- [ ] Companion decoder/sanitizer for `ManagerWithMerkleVerification`.
+- [ ] Tests under `test/` (fork-based, mirroring existing helper tests).
+- [ ] Gas-refinement pass (e.g. `unchecked` loop increments, caching) deferred until logic is final.

--- a/src/helper/equivalent-exchange/EquivalentExchange.sol
+++ b/src/helper/equivalent-exchange/EquivalentExchange.sol
@@ -3,9 +3,10 @@ pragma solidity 0.8.21;
 
 import { ERC20 } from "@solmate/tokens/ERC20.sol";
 import { SafeTransferLib } from "@solmate/utils/SafeTransferLib.sol";
+import { Auth, Authority } from "@solmate/auth/Auth.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
-contract EquivalentExchange {
+contract EquivalentExchange is Auth {
 
     using SafeTransferLib for ERC20;
     using Address for address;
@@ -18,6 +19,8 @@ contract EquivalentExchange {
     error DanglingApproval(address token);
     error InsufficientReturn(uint256 totalIn, uint256 totalOut);
 
+    constructor(address _owner, Authority _authority) Auth(_owner, _authority) { }
+
     function execute(
         ERC20[] calldata tokens,
         uint256[] calldata amountsIn,
@@ -25,6 +28,7 @@ contract EquivalentExchange {
         bytes[] calldata targetData
     )
         external
+        requiresAuth
     {
         uint256 tokensLength = tokens.length;
         if (tokensLength != amountsIn.length) revert LengthMismatch();

--- a/src/helper/equivalent-exchange/EquivalentExchange.sol
+++ b/src/helper/equivalent-exchange/EquivalentExchange.sol
@@ -5,7 +5,7 @@ import { ERC20 } from "@solmate/tokens/ERC20.sol";
 import { SafeTransferLib } from "@solmate/utils/SafeTransferLib.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
-contract EquivalentExchange is ReentrancyGuard {
+contract EquivalentExchange {
 
     using SafeTransferLib for ERC20;
     using Address for address;

--- a/src/helper/equivalent-exchange/EquivalentExchange.sol
+++ b/src/helper/equivalent-exchange/EquivalentExchange.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { ERC20 } from "@solmate/tokens/ERC20.sol";
+import { SafeTransferLib } from "@solmate/utils/SafeTransferLib.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+contract EquivalentExchange is ReentrancyGuard {
+
+    using SafeTransferLib for ERC20;
+    using Address for address;
+
+    uint256 internal constant NORMALIZED_DECIMALS = 18;
+
+    event Executed(address indexed caller, uint256 totalIn, uint256 totalOut);
+
+    error LengthMismatch();
+    error DanglingApproval(address token);
+    error InsufficientReturn(uint256 totalIn, uint256 totalOut);
+
+    function execute(
+        ERC20[] calldata tokens,
+        uint256[] calldata amountsIn,
+        address[] calldata targets,
+        bytes[] calldata targetData
+    )
+        external
+    {
+        uint256 tokensLength = tokens.length;
+        if (tokensLength != amountsIn.length) revert LengthMismatch();
+
+        uint256 targetsLength = targets.length;
+        if (targetsLength != targetData.length) revert LengthMismatch();
+
+        uint8[] memory tokenDecimals = new uint8[](tokensLength);
+        uint256 totalIn;
+
+        for (uint256 i; i < tokensLength; ++i) {
+            ERC20 token = tokens[i];
+            uint8 decimals = token.decimals();
+            tokenDecimals[i] = decimals;
+
+            uint256 amountIn = amountsIn[i];
+            if (amountIn > 0) {
+                token.safeTransferFrom(msg.sender, address(this), amountIn);
+                totalIn += _normalize(amountIn, decimals);
+            }
+
+            if (token.allowance(msg.sender, address(this)) != 0) {
+                revert DanglingApproval(address(token));
+            }
+        }
+
+        for (uint256 i; i < targetsLength; ++i) {
+            targets[i].functionCall(targetData[i]);
+        }
+
+        uint256 totalOut;
+
+        for (uint256 i; i < tokensLength; ++i) {
+            ERC20 token = tokens[i];
+            uint256 balance = token.balanceOf(address(this));
+            if (balance > 0) token.safeTransfer(msg.sender, balance);
+            totalOut += _normalize(balance, tokenDecimals[i]);
+        }
+
+        if (totalOut < totalIn) revert InsufficientReturn(totalIn, totalOut);
+
+        emit Executed(msg.sender, totalIn, totalOut);
+    }
+
+    function _normalize(uint256 amount, uint8 decimals) internal pure returns (uint256) {
+        if (decimals <= NORMALIZED_DECIMALS) {
+            return amount * (10 ** (NORMALIZED_DECIMALS - decimals));
+        }
+        return amount / (10 ** (decimals - NORMALIZED_DECIMALS));
+    }
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new execution helper that batches ERC20 inputs with a sequence of target calls, then returns any remaining token balances to the caller.
  * Enforces a 1:1 “no net loss” outcome using 18-decimal normalization for input vs. returned totals.
  * Added detailed documentation describing supported token expectations and the expected behavior on failure.
* **Bug Fixes**
  * Added stricter input validation for matching parameter lengths.
  * Added protections against dangling token allowances and execution that results in insufficient returned value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->