### PR TITLE
Move rate limit behavior out of `UManager`

### DIFF
--- a/src/micro-managers/DexAggregatorUManager.sol
+++ b/src/micro-managers/DexAggregatorUManager.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { UManager, FixedPointMathLib, ERC20 } from "src/micro-managers/UManager.sol";
+import { RateLimitUManager } from "src/micro-managers/RateLimitUManager.sol";
+import { FixedPointMathLib } from "@solmate/utils/FixedPointMathLib.sol";
+import { ERC20 } from "@solmate/tokens/ERC20.sol";
 import { AggregationRouterV5 } from "src/interfaces/AggregationRouterV5.sol";
 import { PriceRouter } from "src/interfaces/PriceRouter.sol";
 
@@ -11,7 +13,7 @@ import { PriceRouter } from "src/interfaces/PriceRouter.sol";
  * - AggregationRouterV5.swap, with all desired addresses.
  * @custom:security-contact security@molecularlabs.io
  */
-contract DexAggregatorUManager is UManager {
+contract DexAggregatorUManager is RateLimitUManager {
 
     using FixedPointMathLib for uint256;
 
@@ -54,7 +56,7 @@ contract DexAggregatorUManager is UManager {
         address _router,
         address _priceRouter
     )
-        UManager(_owner, _manager, _boringVault)
+        RateLimitUManager(_owner, _manager, _boringVault)
     {
         router = AggregationRouterV5(_router);
         priceRouter = PriceRouter(_priceRouter);

--- a/src/micro-managers/DexSwapperUManager.sol
+++ b/src/micro-managers/DexSwapperUManager.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { UManager, FixedPointMathLib, ERC20 } from "src/micro-managers/UManager.sol";
+import { RateLimitUManager } from "src/micro-managers/RateLimitUManager.sol";
+import { FixedPointMathLib } from "@solmate/utils/FixedPointMathLib.sol";
+import { ERC20 } from "@solmate/tokens/ERC20.sol";
 import { IUniswapV3Router } from "src/interfaces/IUniswapV3Router.sol";
 import { PriceRouter } from "src/interfaces/PriceRouter.sol";
 import { DecoderCustomTypes } from "src/interfaces/DecoderCustomTypes.sol";
@@ -13,7 +15,7 @@ import { BalancerVault } from "src/interfaces/BalancerVault.sol";
  * - IUniswapV3Router.exactInput(params), with all desired paths.
  * @custom:security-contact security@molecularlabs.io
  */
-contract DexSwapperUManager is UManager {
+contract DexSwapperUManager is RateLimitUManager {
 
     using FixedPointMathLib for uint256;
 
@@ -75,7 +77,7 @@ contract DexSwapperUManager is UManager {
         address _balancerVault,
         address _priceRouter
     )
-        UManager(_owner, _manager, _boringVault)
+        RateLimitUManager(_owner, _manager, _boringVault)
     {
         router = IUniswapV3Router(_router);
         balancerVault = BalancerVault(_balancerVault);

--- a/src/micro-managers/RateLimitUManager.sol
+++ b/src/micro-managers/RateLimitUManager.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { UManager } from "src/micro-managers/UManager.sol";
+
+abstract contract RateLimitUManager is UManager {
+
+    // ========================================= STATE =========================================
+
+    /**
+     * @notice The period in seconds for the rate limit.
+     */
+    uint16 public period;
+
+    /**
+     * @notice The number of calls allowed per period.
+     */
+    uint16 public allowedCallsPerPeriod;
+
+    /**
+     * @notice The number of calls made in the current period.
+     */
+    mapping(uint256 => uint256) public callCountPerPeriod;
+
+    //============================== ERRORS ===============================
+
+    error RateLimitUManager__CallCountExceeded();
+
+    //============================== EVENTS ===============================
+
+    event PeriodUpdated(uint16 oldPeriod, uint16 newPeriod);
+    event AllowedCallsPeriodUpdated(uint16 oldAllowance, uint16 newAllowance);
+
+    //============================== MODIFIERS ===============================
+
+    modifier enforceRateLimit() {
+        // Use parenthesis to avoid stack too deep error.
+        {
+            // We include this call in the current call count for period.
+            uint256 currentCallCountForPeriod = callCountPerPeriod[block.timestamp % period] + 1;
+            if (currentCallCountForPeriod > allowedCallsPerPeriod) {
+                revert RateLimitUManager__CallCountExceeded();
+            }
+            callCountPerPeriod[block.timestamp % period] = currentCallCountForPeriod;
+        }
+        _;
+    }
+
+    constructor(address _owner, address _manager, address _boringVault) UManager(_owner, _manager, _boringVault) { }
+
+    // ========================================= ADMIN FUNCTIONS =========================================
+
+    /**
+     * @notice Sets the duration of the period.
+     * @dev Callable by MULTISIG_ROLE.
+     */
+    function setPeriod(uint16 _period) external requiresAuth {
+        emit PeriodUpdated(period, _period);
+        period = _period;
+    }
+
+    /**
+     * @notice Sets the number of calls allowed per period.
+     * @dev Callable by MULTISIG_ROLE.
+     */
+    function setAllowedCallsPerPeriod(uint16 _allowedCallsPerPeriod) external requiresAuth {
+        emit AllowedCallsPeriodUpdated(allowedCallsPerPeriod, _allowedCallsPerPeriod);
+        allowedCallsPerPeriod = _allowedCallsPerPeriod;
+    }
+
+}

--- a/src/micro-managers/RateLimitUManager.sol
+++ b/src/micro-managers/RateLimitUManager.sol
@@ -3,6 +3,10 @@ pragma solidity 0.8.21;
 
 import { UManager } from "src/micro-managers/UManager.sol";
 
+/**
+ * @title Rate Limit UManager
+ * @notice Abstract UManager that enforces a maximum number of manage calls within a rolling time window.
+ */
 abstract contract RateLimitUManager is UManager {
 
     // ========================================= STATE =========================================
@@ -24,15 +28,22 @@ abstract contract RateLimitUManager is UManager {
 
     //============================== ERRORS ===============================
 
+    /// @notice Thrown when the number of calls in the current period exceeds the allowed limit.
     error RateLimitUManager__CallCountExceeded();
 
     //============================== EVENTS ===============================
 
+    /// @notice Emitted when the rate limit period is updated.
     event PeriodUpdated(uint16 oldPeriod, uint16 newPeriod);
+    /// @notice Emitted when the number of allowed calls per period is updated.
     event AllowedCallsPeriodUpdated(uint16 oldAllowance, uint16 newAllowance);
 
     //============================== MODIFIERS ===============================
 
+    /**
+     * @notice Enforces the configured rate limit on the function it modifies.
+     * @dev Increments the call count for the current period and reverts if the limit is exceeded.
+     */
     modifier enforceRateLimit() {
         // Use parenthesis to avoid stack too deep error.
         {
@@ -46,12 +57,19 @@ abstract contract RateLimitUManager is UManager {
         _;
     }
 
+    /**
+     * @notice Constructor for the RateLimitUManager.
+     * @param _owner The address that will own this contract.
+     * @param _manager The ManagerWithMerkleVerification this uManager works with.
+     * @param _boringVault The BoringVault this uManager works with.
+     */
     constructor(address _owner, address _manager, address _boringVault) UManager(_owner, _manager, _boringVault) { }
 
     // ========================================= ADMIN FUNCTIONS =========================================
 
     /**
      * @notice Sets the duration of the period.
+     * @param _period The new period duration in seconds.
      * @dev Callable by MULTISIG_ROLE.
      */
     function setPeriod(uint16 _period) external requiresAuth {
@@ -61,6 +79,7 @@ abstract contract RateLimitUManager is UManager {
 
     /**
      * @notice Sets the number of calls allowed per period.
+     * @param _allowedCallsPerPeriod The new number of calls allowed per period.
      * @dev Callable by MULTISIG_ROLE.
      */
     function setAllowedCallsPerPeriod(uint16 _allowedCallsPerPeriod) external requiresAuth {

--- a/src/micro-managers/UManager.sol
+++ b/src/micro-managers/UManager.sol
@@ -1,55 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { FixedPointMathLib } from "@solmate/utils/FixedPointMathLib.sol";
 import { ManagerWithMerkleVerification } from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import { ERC20 } from "@solmate/tokens/ERC20.sol";
 import { Auth, Authority } from "@solmate/auth/Auth.sol";
 
 abstract contract UManager is Auth {
-
-    using FixedPointMathLib for uint256;
-
-    // ========================================= STATE =========================================
-
-    /**
-     * @notice The period in seconds for the rate limit.
-     */
-    uint16 public period;
-
-    /**
-     * @notice The number of calls allowed per period.
-     */
-    uint16 public allowedCallsPerPeriod;
-
-    /**
-     * @notice The number of calls made in the current period.
-     */
-    mapping(uint256 => uint256) public callCountPerPeriod;
-
-    //============================== ERRORS ===============================
-
-    error UManager__CallCountExceeded();
-
-    //============================== EVENTS ===============================
-
-    event PeriodUpdated(uint16 oldPeriod, uint16 newPeriod);
-    event AllowedCallsPeriodUpdated(uint16 oldAllowance, uint16 newAllowance);
-
-    //============================== MODIFIERS ===============================
-
-    modifier enforceRateLimit() {
-        // Use parenthesis to avoid stack too deep error.
-        {
-            // We include this call in the current call count for period.
-            uint256 currentCallCountForPeriod = callCountPerPeriod[block.timestamp % period] + 1;
-            if (currentCallCountForPeriod > allowedCallsPerPeriod) {
-                revert UManager__CallCountExceeded();
-            }
-            callCountPerPeriod[block.timestamp % period] = currentCallCountForPeriod;
-        }
-        _;
-    }
 
     //============================== IMMUTABLES ===============================
 
@@ -69,24 +25,6 @@ abstract contract UManager is Auth {
     }
 
     // ========================================= ADMIN FUNCTIONS =========================================
-
-    /**
-     * @notice Sets the duration of the period.
-     * @dev Callable by MULTISIG_ROLE.
-     */
-    function setPeriod(uint16 _period) external requiresAuth {
-        emit PeriodUpdated(period, _period);
-        period = _period;
-    }
-
-    /**
-     * @notice Sets the number of calls allowed per period.
-     * @dev Callable by MULTISIG_ROLE.
-     */
-    function setAllowedCallsPerPeriod(uint16 _allowedCallsPerPeriod) external requiresAuth {
-        emit AllowedCallsPeriodUpdated(allowedCallsPerPeriod, _allowedCallsPerPeriod);
-        allowedCallsPerPeriod = _allowedCallsPerPeriod;
-    }
 
     /**
      * @notice Allows auth to set token approvals to zero.

--- a/test/micro-managers/DexAggregatorUManager.t.sol
+++ b/test/micro-managers/DexAggregatorUManager.t.sol
@@ -15,7 +15,7 @@ import { BalancerVault } from "src/interfaces/BalancerVault.sol";
 import { IUniswapV3Router } from "src/interfaces/IUniswapV3Router.sol";
 import { DecoderCustomTypes } from "src/interfaces/DecoderCustomTypes.sol";
 import { RolesAuthority, Authority } from "@solmate/auth/authorities/RolesAuthority.sol";
-import { DexAggregatorUManager, UManager } from "src/micro-managers/DexAggregatorUManager.sol";
+import { DexAggregatorUManager, RateLimitUManager } from "src/micro-managers/DexAggregatorUManager.sol";
 import { PriceRouter } from "src/interfaces/PriceRouter.sol";
 import { AggregationRouterV5 } from "src/interfaces/AggregationRouterV5.sol";
 
@@ -158,7 +158,7 @@ contract DexAggregatorUManagerTest is Test, MainnetAddresses {
 
         // Check rate limit reverts.
         dexAggregatorUManager.setAllowedCallsPerPeriod(1);
-        vm.expectRevert(abi.encodeWithSelector(UManager.UManager__CallCountExceeded.selector));
+        vm.expectRevert(abi.encodeWithSelector(RateLimitUManager.RateLimitUManager__CallCountExceeded.selector));
         dexAggregatorUManager.swapWith1Inch(manageProofs, decodersAndSanitizers, WETH, 100e18, WEETH, swapData);
 
         // uManager should also be able to revoke approvals to router.

--- a/test/micro-managers/DexSwapperUManager.t.sol
+++ b/test/micro-managers/DexSwapperUManager.t.sol
@@ -15,7 +15,7 @@ import { BalancerVault } from "src/interfaces/BalancerVault.sol";
 import { IUniswapV3Router } from "src/interfaces/IUniswapV3Router.sol";
 import { DecoderCustomTypes } from "src/interfaces/DecoderCustomTypes.sol";
 import { RolesAuthority, Authority } from "@solmate/auth/authorities/RolesAuthority.sol";
-import { DexSwapperUManager, UManager } from "src/micro-managers/DexSwapperUManager.sol";
+import { DexSwapperUManager, RateLimitUManager } from "src/micro-managers/DexSwapperUManager.sol";
 import { PriceRouter } from "src/interfaces/PriceRouter.sol";
 
 import { Test, stdStorage, StdStorage, stdError, console } from "@forge-std/Test.sol";
@@ -320,7 +320,7 @@ contract DexSwapperUManagerTest is Test, MainnetAddresses {
         fees[0] = 500;
 
         // Rate limit set to zero, so call reverts.
-        vm.expectRevert(abi.encodeWithSelector(UManager.UManager__CallCountExceeded.selector));
+        vm.expectRevert(abi.encodeWithSelector(RateLimitUManager.RateLimitUManager__CallCountExceeded.selector));
         dexSwapperUManager.swapWithUniswapV3(manageProofs, decodersAndSanitizers, path, fees, 10e18, 0, block.timestamp);
     }
 


### PR DESCRIPTION
This moves the rate limit behavior of `UManager` into `RateLimitUManager`, and updates downstream inheritance trees to keep behavior of all UManager implementations unchanged.  This leaves the `UManager` itself somewhat empty, but it is used as a base for #324 and the rate limit features are incompatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable slippage protection for DEX aggregation swaps.
  * Introduced adjustable rate limits for selected manager actions.
  * Added an admin setting to control allowed swap slippage.

* **Bug Fixes**
  * Swap approvals are now cleaned up after use when possible.
  * Failed swaps now revert if the received value falls below the configured slippage threshold.

* **Refactor**
  * Updated swap managers to use a shared rate-limiting foundation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->